### PR TITLE
Update fr-FR_details.xml

### DIFF
--- a/local-details/fr-FR_details.xml
+++ b/local-details/fr-FR_details.xml
@@ -8,7 +8,7 @@
 	<version>3.9.1</version>
 	<downloads>
 	<downloadurl type="full" format="zip">
-	https://github.com/FLEXIcontent/flexicontent-translations/releases/tag/latest/fr-FR.zip
+	https://github.com/FLEXIcontent/flexicontent-translations/releases/download/latest/fr-FR.zip
 	</downloadurl>
 	</downloads>
 	<tags>


### PR DESCRIPTION
The old URL displays an error instead of installing the update: Failed to extract file: fr-FR.zip